### PR TITLE
Implements feature to substitute specific placeholder values

### DIFF
--- a/main.go
+++ b/main.go
@@ -10,15 +10,31 @@ import (
 	"github.com/antchfx/xmlquery"
 )
 
+// Custom flag type to handle multiple -p flags
+type placeholderFlag []string
+
+func (p *placeholderFlag) String() string {
+	return fmt.Sprint(*p)
+}
+
+func (p *placeholderFlag) Set(value string) error {
+	*p = append(*p, value)
+	return nil
+}
+
 type options struct {
 	baseURL, input, replace string
 	showBase                bool
+	placeholders            map[string]string
+	placeholderArgs         placeholderFlag
 }
 
 var opt *options
 
 func init() {
-	opt = &options{}
+	opt = &options{
+		placeholders: make(map[string]string),
+	}
 
 	flag.StringVar(&opt.input, "i", "", "")
 	flag.StringVar(&opt.input, "input", "", "")
@@ -29,27 +45,41 @@ func init() {
 	flag.StringVar(&opt.replace, "r", "", "")
 	flag.StringVar(&opt.replace, "replace", "", "")
 
+	// Add custom flag for placeholders
+	flag.Var(&opt.placeholderArgs, "p", "Specify placeholder value (format: name=value)")
+	flag.Var(&opt.placeholderArgs, "placeholder", "Specify placeholder value (format: name=value)")
+
 	flag.Usage = func() {
 		h := []string{
 			"Usage:",
 			"  wadl-dumper -i http://domain.tld/application.wadl [options...]",
 			"  wadl-dumper -i /path/to/wadl.xml --show-base -r \"-alert(1)-\"",
+			"  wadl-dumper -i /path/to/wadl.xml -p slug=myslug -p projectId=test123",
 			"",
 			"Options:",
 			"  -i, --input <URL/FILE>         URL/path to WADL file",
 			"  -b, --show-base                Add base URL to paths",
-			"  -r, --replace <string>         Replace all placeholder with given value",
+			"  -r, --replace <string>         Replace all unspecified placeholders with given value",
+			"  -p, --placeholder <name=value> Replace specific placeholder with given value (can be used multiple times)",
 			"  -h, --help                     Show its help text",
 			"",
 		}
 
 		fmt.Fprint(os.Stderr, strings.Join(h, "\n"))
 	}
-
-	flag.Parse()
 }
 
-func error(message string) {
+func parsePlaceholders() {
+	for _, p := range opt.placeholderArgs {
+		parts := strings.SplitN(p, "=", 2)
+		if len(parts) == 2 {
+			name, value := parts[0], parts[1]
+			opt.placeholders[name] = value
+		}
+	}
+}
+
+func errorExit(message string) {
 	err := fmt.Sprintf("Error! %s\n", message)
 	fmt.Fprint(os.Stderr, err)
 	os.Exit(1)
@@ -73,12 +103,43 @@ func replaceNth(s, old string, new string, n int) string {
 	return s
 }
 
+// replacePlaceholders replaces placeholders in the path with values from the placeholders map
+// or with the default replace value if specified
+func replacePlaceholders(path string) string {
+	// Regex to find placeholders in the format {name}
+	re := regexp.MustCompile(`\{([^{}]+)\}`)
+
+	// Use a replacement function to handle each match
+	result := re.ReplaceAllStringFunc(path, func(match string) string {
+		// Extract the placeholder name without braces
+		name := match[1 : len(match)-1]
+
+		// Check if we have a specific value for this placeholder
+		if value, exists := opt.placeholders[name]; exists {
+			return value
+		}
+
+		// If no specific value but we have a default replace value, use that
+		if opt.replace != "" {
+			return opt.replace
+		}
+
+		// Otherwise, leave the placeholder as is
+		return match
+	})
+
+	return result
+}
+
 func main() {
+	flag.Parse()
+	parsePlaceholders()
+
 	var path string
 	var wadl *xmlquery.Node
 
 	if opt.input == "" {
-		error("Flag -i is required, use -h flag for help.")
+		errorExit("Flag -i is required, use -h flag for help.")
 	}
 
 	if strings.HasPrefix(opt.input, "http") {
@@ -86,19 +147,19 @@ func main() {
 	} else {
 		f, err := os.Open(opt.input)
 		if err != nil {
-			error(fmt.Sprintf("Can't open '%s' file.", opt.input))
+			errorExit(fmt.Sprintf("Can't open '%s' file.", opt.input))
 		}
 
 		wadl, _ = xmlquery.Parse(f)
 	}
 
 	if wadl == nil {
-		error("Can't parse WADL file.")
+		errorExit("Can't parse WADL file.")
 	}
 
 	xmlns := xmlquery.FindOne(wadl, "//application/@xmlns")
-	if !strings.Contains(xmlns.InnerText(), "wadl.dev.java.net") {
-		error("Not a WADL file.")
+	if xmlns == nil || !strings.Contains(xmlns.InnerText(), "wadl.dev.java.net") {
+		errorExit("Not a WADL file.")
 	}
 
 	base := xmlquery.FindOne(wadl, "//resources/@base")
@@ -111,10 +172,8 @@ func main() {
 	for _, paths := range xmlquery.Find(wadl, "//resource/@path") {
 		path = opt.baseURL + paths.InnerText()
 
-		if opt.replace != "" {
-			re := regexp.MustCompile("{.*}")
-			path = re.ReplaceAllString(path, opt.replace)
-		}
+		// Apply placeholder replacements
+		path = replacePlaceholders(path)
 
 		if opt.baseURL != "" {
 			path = replaceNth(path, "//", "/", 2)


### PR DESCRIPTION
This change leaves the functionality of `-r` to replace ALL placeholders. It ADDS another flag `-p` that can be specified multiple times from the command line ( `wadl-dumper ...args... -p slug=123 -p projectId=456 -p convoId=678`  for example)  so that instead of replacing all placeholders with the same value, we have a way to specify each value to replace. Unspecified values will NOT be replaced. 

If `-p` and `-r` are specified at the same time, then the `-p` values will be replaced with their designated values, and the `-r` will fill all remaining unspecified values with the `-r` designated placeholder.


Example output:
```
$ ./wadl-dumper -i http://example.com/api/application.wadl                           
/v1
/project/{projectId}/vote/ideas
/project/{projectId}/vote/idea/{ideaId}
/project/{projectId}/subscribe/category/{categoryId}
/project/{projectId}/vote/comments


$ ./wadl-dumper -i http://example.com/api/application.wadl -p ideaId=test123 -p categoryId=test456 
/v1
/project/{projectId}/vote/ideas
/project/{projectId}/vote/idea/test123
/project/{projectId}/subscribe/category/test456
/project/{projectId}/vote/comments


$ ./wadl-dumper -i http://example.com/api/application.wadl -p ideaId=test123 -p categoryId=test456  -r abc
/v1
/project/abc/vote/ideas
/project/abc/vote/idea/test123
/project/abc/subscribe/category/test456
/project/abc/vote/comments
```
